### PR TITLE
Qc filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,20 @@ This pipeline performs peak calling for ATAC-seq data using pyCisTopic. It suppo
 #### cisTopic Object Creation
 | Parameter                             | Default | Description                                            |
 | ------------------------------------- | ------- | ------------------------------------------------------ |
-| `--cistopic.min_frag`                 | `1`     | Minimum fragments per peak for inclusion               |
-| `--cistopic.min_cell`                 | `1`     | Minimum cells per peak for inclusion                   |
-| `--cistopic.is_acc`                   | `1`     | Whether data is accessibility data (1=yes, 0=no)       |
+| `--cistopic.min_frag`                 | `0`     | Minimum fragments per peak for inclusion               |
+| `--cistopic.min_cell`                 | `0`     | Minimum cells per peak for inclusion                   |
+| `--cistopic.is_acc`                   | `0`     | Whether data is accessibility data (1=yes, 0=no)       |
 | `--cistopic.split_pattern`            | `'___'` | Pattern for splitting cell identifiers                 |
 | `--cistopic.check_for_duplicates`     | `true`  | Check for duplicate peaks in consensus                 |
 | `--cistopic.use_automatic_thresholds` | `true`  | Use automatic QC thresholds based on data distribution |
+| `--cistopic.filter_low_quality_cells` | `false` | Keep only barcodes that pass QC thresholds             |
+
+#### AnnData Attachment and GEX Integration
+| Parameter                           | Default | Description                                                                  |
+| ----------------------------------- | ------- | ---------------------------------------------------------------------------- |
+| `--cistopic.annotated_only_atac`    | `false` | Keep only annotated cells in ATAC AnnData attachment (`--how inner`)         |
+| `--cistopic.gex_filtered`           | `true`  | Use `filtered_feature_bc_matrix`; set `false` to use `raw_feature_bc_matrix` |
+| `--cistopic.annotated_only_gex`     | `false` | Keep only annotated cells in GEX AnnData attachment (`--how inner`)          |
 
 ### Parameter Usage Examples
 ```bash
@@ -121,6 +129,10 @@ nextflow run main.nf --callPeaks --inferConsensus --attachGEX --sample_table sam
 # Attach GEX data to existing ATAC data
 nextflow run main.nf --attachGEX --sample_table updated_sample.csv --celltypes celltypes.csv \
   --atac_adata atac_anndata.csv
+
+# Use raw CellRanger matrices instead of filtered_feature_bc_matrix
+nextflow run main.nf --attachGEX --sample_table updated_sample.csv --celltypes celltypes.csv \
+  --atac_adata atac_anndata.csv --cistopic.gex_filtered false
 ```
 
 ### Compute Resources
@@ -222,18 +234,21 @@ This will create a `consensus_peaks.bed` file, `cisTopic` and `.h5ad` objects fo
 results/
 ├── consensus_peaks.bed # consensus peaks
 ├── combined_cistopic_object.pkl
-├── combined.h5ad
+├── combined_anndata_object.h5ad
 ├── log/
 │   └── inferconsensus.log
+├── anndata/
+│   ├── WS_wEMB13400228/
+│   │   └── WS_wEMB13400228_atac.h5ad
+│   └── WS_wEMB13400229/
+│       └── WS_wEMB13400229_atac.h5ad
 └── cistopic/
     ├── WS_wEMB13400228/
     │   ├── qc/
-    │   ├── WS_wEMB13400228_cistopic_obj.pkl
-    │   └── WS_wEMB13400228.h5ad
+    │   └── WS_wEMB13400228_cistopic_obj.pkl
     └── WS_wEMB13400229/
         ├── qc/
-        ├── WS_wEMB13400229_cistopic_obj.pkl
-        └── WS_wEMB13400229.h5ad
+        └── WS_wEMB13400229_cistopic_obj.pkl
 ```
 
 ### 3. Attach GEX data to ATAC data
@@ -254,14 +269,19 @@ This will create multiome objects (.h5mu) and combined AnnData objects (.h5ad) w
 results/
 ├── anndata/
 │   ├── WS_wEMB13400228/
-│   │   ├── WS_wEMB13400228_coupled.h5mu
-│   │   └── WS_wEMB13400228_coupled.h5ad
+│   │   ├── WS_wEMB13400228.h5mu
+│   │   ├── WS_wEMB13400228_sharedbarcodes_gex.h5ad
+│   │   └── WS_wEMB13400228_sharedbarcodes_atac.h5ad
 │   └── WS_wEMB13400229/
-│       ├── WS_wEMB13400229_coupled.h5mu
-│       └── WS_wEMB13400229_coupled.h5ad
+│       ├── WS_wEMB13400229.h5mu
+│       ├── WS_wEMB13400229_sharedbarcodes_gex.h5ad
+│       └── WS_wEMB13400229_sharedbarcodes_atac.h5ad
 └── log/
     └── attachgex.log
 ```
+
+By default the GEX step reads CellRanger `filtered_feature_bc_matrix` directories.
+Set `--cistopic.gex_filtered false` to use `raw_feature_bc_matrix` instead.
 
 ### 4. Infer consensus peaks and attach GEX in one go
 To run consensus peak inference and GEX attachment together:

--- a/configs/anndata_attachcelltypes.config
+++ b/configs/anndata_attachcelltypes.config
@@ -2,6 +2,7 @@ process {
     withName: '.*ANNDATA_ATTACHCELLTYPES_GEX' {
         ext.barcode_column = 'barcode'
         ext.output = { "${meta.id}_gex.h5ad" }
+        ext.args = { params.cistopic.annotated_only_gex ? "--how inner" : "--how left" }
         cpus       = 1
         queue      = 'normal'
         memory     = { 10.GB + 30.GB * (task.attempt - 1) }
@@ -16,6 +17,7 @@ process {
     withName: '.*ANNDATA_ATTACHCELLTYPES_ATAC' {
         ext.barcode_column = 'barcode'
         ext.output = { "${meta.id}_atac.h5ad" }
+        ext.args = { params.cistopic.annotated_only_atac ? "--how inner" : "--how left" }
         cpus       = 1
         queue      = 'normal'
         memory     = { 10.GB + 30.GB * (task.attempt - 1) }

--- a/configs/cistopic_createobject.config
+++ b/configs/cistopic_createobject.config
@@ -7,7 +7,8 @@ process {
                 params.cistopic.is_acc ? "--is_acc ${params.cistopic.is_acc}" : "",
                 params.cistopic.split_pattern ? "--split_pattern '${params.cistopic.split_pattern}'" : "",
                 params.cistopic.check_for_duplicates ? "--check_for_duplicates" : "",
-                params.cistopic.use_automatic_thresholds ? "--use_automatic_thresholds" : "--unique_fragments_threshold 0 --tss_enrichment_threshold 0 --frip_threshold 0"
+                params.cistopic.use_automatic_thresholds ? "--use_automatic_thresholds" : "--unique_fragments_threshold 0 --tss_enrichment_threshold 0 --frip_threshold 0",
+                params.cistopic.filter_low_quality_cells ? "--filter_low_quality_cells" : "",
             ].join(' ')
         }
         cpus       = 4

--- a/configs/cistopic_createobject.config
+++ b/configs/cistopic_createobject.config
@@ -2,9 +2,9 @@ process {
     withName: '.*CISTOPIC_CREATEOBJECT' {
         ext.args      = {
             [   
-                params.cistopic.min_frag ? "--min_frag ${params.cistopic.min_frag}" : "",
-                params.cistopic.min_cell ? "--min_cell ${params.cistopic.min_cell}" : "",
-                params.cistopic.is_acc ? "--is_acc ${params.cistopic.is_acc}" : "",
+                "--min_frag ${params.cistopic.min_frag}",
+                "--min_cell ${params.cistopic.min_cell}",
+                "--is_acc ${params.cistopic.is_acc}",
                 params.cistopic.split_pattern ? "--split_pattern '${params.cistopic.split_pattern}'" : "",
                 params.cistopic.check_for_duplicates ? "--check_for_duplicates" : "",
                 params.cistopic.use_automatic_thresholds ? "--use_automatic_thresholds" : "--unique_fragments_threshold 0 --tss_enrichment_threshold 0 --frip_threshold 0",

--- a/configs/cistopic_createobject.config
+++ b/configs/cistopic_createobject.config
@@ -11,9 +11,9 @@ process {
                 params.cistopic.filter_low_quality_cells ? "--filter_low_quality_cells" : "",
             ].join(' ')
         }
-        cpus       = 4
-        queue      = { (task.attempt > 2) ? 'hugemem' : 'normal' }
-        memory     = { 100.GB + 100.GB * (task.attempt - 1) }
+        cpus       = 8
+        queue      = { (task.attempt > 3) ? 'teramem' : 'hugemem' }
+        memory     = { 300.GB + 200.GB * (task.attempt - 1) }
         publishDir = [
             mode     : 'link',
             path     : { "${params.output_dir}/cistopic/${meta.id}" },

--- a/main.nf
+++ b/main.nf
@@ -151,10 +151,11 @@ workflow {
         }
 
     // Collect versions
+    def versions_header = "\"NF-ATAC\":\n    name: ${workflow.manifest.name}\n    version: ${workflow.manifest.version}\n    description: \"${workflow.manifest.description}\"\n"
     PYCISTOPIC.out.versions
         .splitText(by: 20)
         .unique()
-        .collectFile(name: 'versions.yml', storeDir: params.output_dir, sort: true)
+        .collectFile(name: 'versions.yml', storeDir: params.output_dir, sort: true, seed: versions_header)
         .subscribe { __ -> 
             log.info("Versions saved to ${params.output_dir}/versions.yml")
         }

--- a/main.nf
+++ b/main.nf
@@ -132,7 +132,8 @@ workflow {
         tss_bed,
         params.callPeaks,
         params.inferConsensus,
-        params.attachGEX
+        params.attachGEX,
+        params.cistopic.gex_filtered
     )
 
     // Collect ATAC anndata object paths (if generated)

--- a/modules/local/anndata/attachcelltypes/main.nf
+++ b/modules/local/anndata/attachcelltypes/main.nf
@@ -12,16 +12,17 @@ process ANNDATA_ATTACHCELLTYPES {
     path 'versions.yml'            , emit: versions
     
     script:
+     def args = task.ext.args ?: '--how left'
     barcode_column = task.ext.barcode_column ?: "obs_names"
     output = task.ext.output ?: "${meta.id}.h5ad"
     """
     attach_celltypes.py \
+        ${args} \
         --h5ad_file ${h5ad} \
         --sample_id ${meta.id} \
         --metadata ${metadata} \
         --barcode_column ${barcode_column} \
         --logfile .attach_celltypes.log \
-        --how left \
         --output $output
     
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/anndata/attachcelltypes/main.nf
+++ b/modules/local/anndata/attachcelltypes/main.nf
@@ -21,6 +21,7 @@ process ANNDATA_ATTACHCELLTYPES {
         --metadata ${metadata} \
         --barcode_column ${barcode_column} \
         --logfile .attach_celltypes.log \
+        --how left \
         --output $output
     
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/anndata/couplemultiome/main.nf
+++ b/modules/local/anndata/couplemultiome/main.nf
@@ -19,7 +19,7 @@ process ANNDATA_COUPLEMULTIOME {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}_coupled"
+    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     couple_multiome.py \
             --gex ${gex} \
@@ -36,11 +36,11 @@ process ANNDATA_COUPLEMULTIOME {
 
     stub:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}_coupled"
+    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch .couple_multiome.log
-    touch ${prefix}_gex.h5ad
-    touch ${prefix}_atac.h5ad
+    touch ${prefix}_sharedbarcodes_gex.h5ad
+    touch ${prefix}_sharedbarcodes_atac.h5ad
     touch ${prefix}.h5mu
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/anndata/couplemultiome/resources/usr/bin/couple_multiome.py
+++ b/modules/local/anndata/couplemultiome/resources/usr/bin/couple_multiome.py
@@ -102,6 +102,15 @@ def main():
     atac_adata = ad.read_h5ad(args.atac)
     logging.info(atac_adata)
 
+    # Create MuData object
+    logging.info("Creating MuData object")
+    mdata = md.MuData({"gex": gex_adata, "atac": atac_adata})
+    logging.info(mdata)
+
+    # Save MuData object
+    logging.info("Saving MuData object")
+    mdata.write_h5mu(f"{args.prefix}.h5mu")
+
     # Subset barcodes to intersection
     logging.info("Subsetting barcodes to intersection")
     common_barcodes = gex_adata.obs_names.intersection(atac_adata.obs_names)
@@ -109,16 +118,10 @@ def main():
     atac_adata = atac_adata[common_barcodes].copy()
     logging.info("Number of common barcodes: %s", common_barcodes.shape[0])
 
-    # Create MuData object
-    logging.info("Creating MuData object")
-    mdata = md.MuData({"gex": gex_adata, "atac": atac_adata}, obs_names=common_barcodes)
-    logging.info(mdata)
-
-    # Save all objects
+    # Save AnnData objects
     logging.info("Saving objects")
-    gex_adata.write_h5ad(f"{args.prefix}_gex.h5ad")
-    atac_adata.write_h5ad(f"{args.prefix}_atac.h5ad")
-    mdata.write_h5mu(f"{args.prefix}_multiome.h5mu")
+    gex_adata.write_h5ad(f"{args.prefix}_sharedbarcodes_gex.h5ad")
+    atac_adata.write_h5ad(f"{args.prefix}_sharedbarcodes_atac.h5ad")
 
 
 if __name__ == "__main__":

--- a/modules/local/cistopic/createobject/main.nf
+++ b/modules/local/cistopic/createobject/main.nf
@@ -24,8 +24,7 @@ process CISTOPIC_CREATEOBJECT {
         --consensus $consensus \\
         --blacklist $blacklist \\
         --qc_dir $qc \\
-        --cpus $task.cpus \\
-        --use_automatic_thresholds
+        --cpus $task.cpus
     
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/cistopic/createobject/module.config
+++ b/modules/local/cistopic/createobject/module.config
@@ -7,7 +7,8 @@ process {
                 "--is_acc 1",
                 "--split_pattern '___'",
                 true ? "--check_for_duplicates" : "",
-                true ? "--use_automatic_thresholds" : "--unique_fragments_threshold 0 --tss_enrichment_threshold 0 --frip_threshold 0"
+                true ? "--use_automatic_thresholds" : "--unique_fragments_threshold 0 --tss_enrichment_threshold 0 --frip_threshold 0",
+                false ? "--filter_low_quality_cells" : "",
             ].join(' ')
         }
         cpus       = 4

--- a/modules/local/cistopic/createobject/resources/usr/bin/create_cistopic.py
+++ b/modules/local/cistopic/createobject/resources/usr/bin/create_cistopic.py
@@ -108,15 +108,26 @@ def init_parser() -> argparse.ArgumentParser:
         help="Pattern to split cell barcode from sample id. Default: '___'",
         default="___",
     )
+    parser.add_argument(
+        "--filter_low_quality_cells",
+        help="Whether to filter low quality cells based on QC metrics. Default: False",
+        action="store_true",
+    )
     return parser
 
 
-def read_metrics(qc_dir: str, sample_id: str, barcodes: ndarray) -> DataFrame:
+def read_metrics(
+    qc_dir: str,
+    sample_id: str,
+    barcodes: ndarray,
+    filter_low_quality_cells: bool = False,
+) -> DataFrame:
     """
     Read QC metrics from <sample_id>.fragments_stats_per_cb.parquet file
     qc_dir (str): directory with QC results
     sample_id (str): sample identifier
     barcodes (List[str]): a list of barcodes that passed filtering
+    filter_low_quality_cells (bool): whether to filter low quality cells
     """
     # get file's path
     fragments_stats_file = os.path.join(
@@ -131,7 +142,10 @@ def read_metrics(qc_dir: str, sample_id: str, barcodes: ndarray) -> DataFrame:
     # read data and filter barcodes
     fragments_stats = read_parquet(fragments_stats_file, engine="pyarrow")
     fragments_stats = fragments_stats.set_index("CB")
-    fragments_stats = fragments_stats.loc[barcodes].copy()
+    fragments_stats["passed_qc"] = False
+    fragments_stats.loc[barcodes, "passed_qc"] = True
+    if filter_low_quality_cells:
+        fragments_stats = fragments_stats.loc[fragments_stats["passed_qc"]].copy()
     return fragments_stats
 
 
@@ -140,7 +154,7 @@ def main():
     parser = init_parser()
     args = parser.parse_args()
 
-    # filter low quality cells
+    # Get barcodes passing QC thresholds and the thresholds used for filtering
     barcodes, thresholds = get_barcodes_passing_qc_for_sample(
         sample_id=args.sample_id,
         pycistopic_qc_output_dir=args.qc_dir,
@@ -151,7 +165,12 @@ def main():
     )
 
     # read fragments stats
-    fragments_stats = read_metrics(args.qc_dir, args.sample_id, barcodes)
+    fragments_stats = read_metrics(
+        args.qc_dir,
+        args.sample_id,
+        barcodes,
+        filter_low_quality_cells=args.filter_low_quality_cells,
+    )
 
     # create a cistopic object
     cistopic_obj = create_cistopic_object_from_fragments(
@@ -159,7 +178,7 @@ def main():
         path_to_regions=args.consensus,
         path_to_blacklist=args.blacklist,
         metrics=fragments_stats,
-        valid_bc=barcodes,
+        valid_bc=None,
         n_cpu=args.cpus,
         min_frag=args.min_frag,
         min_cell=args.min_cell,
@@ -172,14 +191,14 @@ def main():
     # save to pickle file
     with open(f"{args.sample_id}_cistopic_obj.pkl", "wb") as file:
         pickle.dump(cistopic_obj, file)
-    
+
     # save good barcodes and thresholds
-    with open(f"{args.sample_id}_good_cells.txt", 'w') as file:
+    with open(f"{args.sample_id}_good_cells.txt", "w") as file:
         text = "\n".join(barcodes.tolist())
         file.write(text)
-    
+
     # save thresholds
-    with open(f"{args.sample_id}_thresholds.json", 'w') as file:
+    with open(f"{args.sample_id}_thresholds.json", "w") as file:
         json.dump(thresholds, file)
 
     # create anndata object
@@ -188,6 +207,7 @@ def main():
         obs=cistopic_obj.cell_data.infer_objects(),
         var=cistopic_obj.region_data.infer_objects(),
         layers={"binary": cistopic_obj.binary_matrix.T},
+        uns={"thresholds": thresholds},
     )
 
     # save to h5ad file

--- a/modules/local/cistopic/createobject/resources/usr/bin/create_cistopic.py
+++ b/modules/local/cistopic/createobject/resources/usr/bin/create_cistopic.py
@@ -164,6 +164,13 @@ def main():
         use_automatic_thresholds=args.use_automatic_thresholds,
     )
 
+    # Get fully automated thresholds
+    otsu_barcodes, otsu_thresholds = get_barcodes_passing_qc_for_sample(
+        sample_id=args.sample_id,
+        pycistopic_qc_output_dir=args.qc_dir,
+        use_automatic_thresholds=args.use_automatic_thresholds,
+    )
+
     # read fragments stats
     fragments_stats = read_metrics(
         args.qc_dir,
@@ -207,7 +214,7 @@ def main():
         obs=cistopic_obj.cell_data.infer_objects(),
         var=cistopic_obj.region_data.infer_objects(),
         layers={"binary": cistopic_obj.binary_matrix.T},
-        uns={"thresholds": thresholds},
+        uns={"qc_thresholds": thresholds, "otsu_thresholds": otsu_thresholds},
     )
 
     # save to h5ad file

--- a/nextflow.config
+++ b/nextflow.config
@@ -42,9 +42,9 @@ params {
         use_pyranges                 = false
         dont_collapse_duplicates     = false
         // create object
-        min_frag                 = 1
-        min_cell                 = 1
-        is_acc                   = 1
+        min_frag                 = 0
+        min_cell                 = 0
+        is_acc                   = 0
         split_pattern            = '___'
         check_for_duplicates     = true
         use_automatic_thresholds = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,6 +48,7 @@ params {
         split_pattern            = '___'
         check_for_duplicates     = true
         use_automatic_thresholds = true
+        filter_low_quality_cells = false
     }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,6 +49,10 @@ params {
         check_for_duplicates     = true
         use_automatic_thresholds = true
         filter_low_quality_cells = false
+        annotated_only_atac      = false
+        // attach gex
+        gex_filtered       = true
+        annotated_only_gex = false
     }
 }
 

--- a/subworkflows/local/cistopic_attachgex/main.nf
+++ b/subworkflows/local/cistopic_attachgex/main.nf
@@ -11,7 +11,7 @@ workflow CISTOPIC_ATTACHGEX {
 
     main:
     // STEP 0: Get mtx paths from sample table
-    def filt_type = params.cistopic.gex_filtered ? "filtered" : "raw"
+    def filt_type = gex_filtered ? "filtered" : "raw"
     mtx_dirs = sample_table
         .splitCsv(header: true)
         .map{ row ->

--- a/subworkflows/local/cistopic_attachgex/main.nf
+++ b/subworkflows/local/cistopic_attachgex/main.nf
@@ -7,13 +7,15 @@ workflow CISTOPIC_ATTACHGEX {
     sample_table
     celltypes
     atac_adata
+    gex_filtered
 
     main:
     // STEP 0: Get mtx paths from sample table
+    def filt_type = params.cistopic.gex_filtered ? "filtered" : "raw"
     mtx_dirs = sample_table
         .splitCsv(header: true)
         .map{ row ->
-            def mtx_path = file( "${row.path}/raw_feature_bc_matrix" )
+            def mtx_path = file( "${row.path}/${filt_type}_feature_bc_matrix" )
             def meta = [id: row.sample_id, fragments: row.fragments ? row.fragments : null]
             if ( ! mtx_path.exists() ) {
                 error "Matrix directory not found: ${mtx_path}. Please check your sample_table."

--- a/workflows/pycistopic/main.nf
+++ b/workflows/pycistopic/main.nf
@@ -15,6 +15,7 @@ workflow  PYCISTOPIC {
     callPeaksFlag
     inferConsensusFlag
     attachGEXFlag
+    gex_filtered
     
     main:
     versions         = Channel.empty()
@@ -66,7 +67,8 @@ workflow  PYCISTOPIC {
         CISTOPIC_ATTACHGEX(
             updated_samples,
             celltypes,
-            atac
+            atac,
+            gex_filtered
         )
 
         versions = versions.mix(CISTOPIC_ATTACHGEX.out.versions)


### PR DESCRIPTION
## Summary
This PR updates QC filtering behavior and multiome/GEX handling in `nf-atac`, and aligns documentation with the new runtime behavior.

## Main Changes

### 1) QC filtering and cisTopic object creation
- Added a new parameter: `--cistopic.filter_low_quality_cells` (default: `false`).
- Extended `create_cistopic.py` to:
	- support `--filter_low_quality_cells`,
	- track a `passed_qc` flag in fragment stats,
	- optionally filter metrics to passing barcodes,
	- store QC thresholds in AnnData `uns` (`qc_thresholds`, `otsu_thresholds`).
- Updated cisTopic defaults in config:
	- `cistopic.min_frag: 0`
	- `cistopic.min_cell: 0`
	- `cistopic.is_acc: 0`
- `inferConsensus` argument validation now explicitly requires `--celltypes`.

### 2) GEX input and annotation behavior
- Added new parameters:
	- `--cistopic.gex_filtered` (default: `true`)
	- `--cistopic.annotated_only_atac` (default: `false`)
	- `--cistopic.annotated_only_gex` (default: `false`)
- `CISTOPIC_ATTACHGEX` now supports switching between:
	- `filtered_feature_bc_matrix` (default), and
	- `raw_feature_bc_matrix` (`--cistopic.gex_filtered false`).
- Split attach-celltypes behavior for ATAC vs GEX using dedicated process scopes and `--how` selection.

### 3) Multiome output naming and semantics
- Refactored `couple_multiome.py` output behavior:
	- writes full MuData as `<sample>.h5mu`,
	- writes shared-barcode AnnData files as:
		- `<sample>_sharedbarcodes_gex.h5ad`
		- `<sample>_sharedbarcodes_atac.h5ad`
- Updated module prefix handling to use `<sample>` as the base output prefix.

### 4) Workflow/resource/config updates
- Passed `gex_filtered` through top-level workflow wiring.
- Added NF metadata header to generated `versions.yml`.
- Adjusted resources for heavy cisTopic steps (notably createobject and QC retry profile).

### 5) Documentation
- Updated `README.md` to reflect:
	- new parameters and defaults,
	- updated infer-consensus requirements,
	- updated output filenames for multiome and AnnData artifacts,
	- usage of filtered vs raw GEX matrices.

## Files Changed
- `README.md`
- `nextflow.config`
- `main.nf`
- `workflows/pycistopic/main.nf`
- `subworkflows/local/cistopic_attachgex/main.nf`
- `configs/anndata_attachcelltypes.config`
- `configs/cistopic_createobject.config`
- `modules/local/anndata/attachcelltypes/main.nf`
- `modules/local/anndata/couplemultiome/main.nf`
- `modules/local/anndata/couplemultiome/resources/usr/bin/couple_multiome.py`
- `modules/local/cistopic/createobject/main.nf`
- `modules/local/cistopic/createobject/module.config`
- `modules/local/cistopic/createobject/resources/usr/bin/create_cistopic.py`

## Behavior Changes to Highlight in Review
- Existing downstream code expecting `*_coupled.h5ad`/`*_coupled.h5mu` output names must be updated to the new naming scheme.
- If users want raw matrices for GEX attachment, they now need `--cistopic.gex_filtered false`.
- `inferConsensus` now requires `--celltypes` explicitly.

## Suggested Reviewer Focus
- Verify compatibility of downstream consumers with new output filenames.
- Confirm expected behavior when `filter_low_quality_cells` is toggled on/off.
- Confirm attach-GEX behavior for both filtered and raw matrix modes.
- Sanity-check memory/queue changes on representative large datasets.

## Validation
- Code and config changes reviewed against branch diff (`origin/dev...HEAD`).
- No additional pipeline execution was run as part of preparing these notes.
